### PR TITLE
Fix input list in README

### DIFF
--- a/packages/zed-wasm/README.md
+++ b/packages/zed-wasm/README.md
@@ -56,9 +56,5 @@ import { zq } from 'https://cdn.jsdelivr.net/npm/@brimdata/zed-wasm@0.0.3/index.
 Only the zq function is exposed at the moment. It takes an options object and returns an array of Zed Value Objects.
 
 ```ts
-function zq(options: {
-  input?: string;
-  program?: string;
-  inputFormat?: 'auto' | 'arrows' | 'csv' | 'json' | 'line' | 'parquet' | 'vng' | 'zeek' | 'zjson' | 'zng' | 'zson';
-}): Promise<zed.Any[]>;
+function zq(options: { input?: string; program?: string; inputFormat?: 'auto' | 'arrows' | 'csv' | 'json' | 'line' | 'parquet' | 'vng' | 'zeek' | 'zjson' | 'zng' | 'zson' }): Promise<zed.Any[]>;
 ```

--- a/packages/zed-wasm/README.md
+++ b/packages/zed-wasm/README.md
@@ -55,6 +55,23 @@ import { zq } from 'https://cdn.jsdelivr.net/npm/@brimdata/zed-wasm@0.0.3/index.
 
 Only the zq function is exposed at the moment. It takes an options object and returns an array of Zed Value Objects.
 
-```ts
-function zq(options: { input?: string; program?: string; inputFormat?: 'auto' | 'arrows' | 'csv' | 'json' | 'line' | 'parquet' | 'vng' | 'zeek' | 'zjson' | 'zng' | 'zson' }): Promise<zed.Any[]>;
+```js
+function zq(options: {
+  input?: string;
+  program?: string;
+  inputFormat?: InputFormat;
+}): Promise<zed.Any[]>;
+
+type InputFormat =
+  | 'auto'
+  | 'arrows'
+  | 'csv'
+  | 'json'
+  | 'line'
+  | 'parquet'
+  | 'vng'
+  | 'zeek'
+  | 'zjson'
+  | 'zng'
+  | 'zson';
 ```

--- a/packages/zed-wasm/README.md
+++ b/packages/zed-wasm/README.md
@@ -59,6 +59,6 @@ Only the zq function is exposed at the moment. It takes an options object and re
 function zq(options: {
   input?: string;
   program?: string;
-  inputType?: 'auto' | 'csv' | 'ndjson' | 'parquet';
+  inputFormat?: 'auto' | 'arrows' | 'csv' | 'json' | 'line' | 'parquet' | 'vng' | 'zeek' | 'zjson' | 'zng' | 'zson';
 }): Promise<zed.Any[]>;
 ```


### PR DESCRIPTION
While debugging an issue recently, I followed the README and tried to specify an explicit `inputType` and was scratching my head when it didn't work, then noticed here:

https://github.com/brimdata/zealot/blob/62a17d1f6c7e80d39a99e367d4dbf66218727b31/packages/zed-wasm/src/index.ts#L13

...that it's actually `inputFormat`. While I'm at it, I've added the full list of explicit input formats that `zq` ultimately accepts.