### PR TITLE
Drop explicit 0.0.3 reference

### DIFF
--- a/packages/zed-wasm/README.md
+++ b/packages/zed-wasm/README.md
@@ -28,7 +28,7 @@ This packages brings Zed into your browser.
 
 ```html
 <script type="module">
-  import { zq } from 'https://cdn.jsdelivr.net/npm/@brimdata/zed-wasm@0.0.3/index.js';
+  import { zq } from 'https://cdn.jsdelivr.net/npm/@brimdata/zed-wasm/index.js';
 
   const result = await zq({
     input: '1 2 3',


### PR DESCRIPTION
In #8 we dropped one of the explicit `@0.0.3` references in the module import so users would be encouraged to always grab the latest. I spotted this other ref that still needs to be dropped, though.