### PR TITLE
For now, don't show the non-seekable input formats in README

### DIFF
--- a/packages/zed-wasm/README.md
+++ b/packages/zed-wasm/README.md
@@ -69,8 +69,6 @@ type InputFormat =
   | 'csv'
   | 'json'
   | 'line'
-  | 'parquet'
-  | 'vng'
   | 'zeek'
   | 'zjson'
   | 'zng'


### PR DESCRIPTION
Until we fix https://github.com/brimdata/zealot/issues/13, attempts to load formats like Parquet and VNG are going to fail, so I propose we drop them from the README for now to avoid user confusion. If this PR merges I'll make a note-to-self in https://github.com/brimdata/zealot/issues/13 with a reminder to add them back when we address that issue.