### PR TITLE
Clean up zed-wasm README and link to different demo notebook

### DIFF
--- a/packages/zed-wasm/README.md
+++ b/packages/zed-wasm/README.md
@@ -1,6 +1,7 @@
 # zed-wasm
 
-The [Zed](https://zed.brimdata.io/) command line tools built for [Web Assembly](https://webassembly.org/).
+The [Zed](https://zed.brimdata.io/) command line tools built for
+[WebAssembly](https://webassembly.org/).
 
 [View the interactive demo](https://observablehq.com/d/4064e8ce0f7b7e51)
 

--- a/packages/zed-wasm/README.md
+++ b/packages/zed-wasm/README.md
@@ -1,28 +1,21 @@
 # zed-wasm
 
-The zed command line tools built for Web Assembly.
+The [Zed](https://zed.brimdata.io/) command line tools built for [Web Assembly](https://webassembly.org/).
 
-[View the Demo](https://observablehq.com/d/f2b3836df355792b)
+[View the interactive demo](https://observablehq.com/d/4064e8ce0f7b7e51)
 
-[Zed](https://github.com/brimdata/zed) is a suite of technologies for managing, storing, and processing data. It's a
-<b>superset</b> of schema-defined <b>tables</b>, and
-<b>unstructured documents</b>; an emerging concept we call
-<a href="https://zed.brimdata.io/docs/formats#2-zed-a-super-structured-pattern">
-super-structured data
-</a>
-.
+[Zed](https://zed.brimdata.io/) is a suite of technologies for managing,
+storing, and processing data. It's a **superset** of schema-defined **tables**,
+and **unstructured documents**; an emerging concept we call
+[super-structured data](https://zed.brimdata.io/docs/formats#2-zed-a-super-structured-pattern").
 
-The <a href="https://zed.brimdata.io/docs/formats">storage layer</a>
-, <a href="https://zed.brimdata.io/docs/formats/zed">type system</a>
-,
-<a href="https://zed.brimdata.io/docs/language/overview">
-query language
-</a>
-, and <a href="https://zed.brimdata.io/docs/commands/zq">zq</a>
-command-line utility are just a few of the tools Zed offers to the
-data community.
+The [storage layer](https://zed.brimdata.io/docs/formats),
+[type system](https://zed.brimdata.io/docs/formats/zed),
+[query language](https://zed.brimdata.io/docs/language/overview),
+and [`zq`](https://zed.brimdata.io/docs/commands/zq) command-line utility are
+just a few of the tools Zed offers to the data community.
 
-This packages brings Zed into your browser.
+This package brings Zed into your browser.
 
 ## Example
 
@@ -45,7 +38,9 @@ This packages brings Zed into your browser.
 
 ## Installation
 
-The easiest way to work with the published version of zed-wasm is to use a CDN like JsDelivr. Use the url below inside of a `script` tag with the type property set to "module".
+The easiest way to work with the published version of zed-wasm is to use a CDN
+like [JsDelivr](https://www.jsdelivr.com/). Use the URL below inside of a
+`script` tag with the `type` property set to `"module"`.
 
 ```js
 const { zq } = await import('https://cdn.jsdelivr.net/npm/@brimdata/zed-wasm/index.js');
@@ -77,7 +72,7 @@ type InputFormat =
   | 'zson';
 ```
 
-### Running Browser Test
+### Running Browser Tests
 
 Tests are written with Mocha. To run them:
 


### PR DESCRIPTION
The [Introducing zed-wasm](https://observablehq.com/d/4064e8ce0f7b7e51) notebook I recently drafted and circulated for review seems to have been well-liked by those who read it. Since it's a more comprehensive look at what's possible with zed-wasm, in this PR I'm proposing that we link to it as the first-look "demo" of zed-wasm. I'd ask that reviewers who've not yet taken a look at the notebook take this opportunity to give it a read and provide any feedback, since my next step would be to link to the same notebook from a brimdata.io blog post, and then encourage others to back-link to it from their own Observable notebooks so they don't need to repeat a lot of "intro context" to audiences that may be less familiar with Observable, JavaScript, or Zed basics.

While I was in the README, I found a few other things to clean up that are also taken care of here.