### PR TITLE
Lake Bin Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "@swc/helpers": "~0.4.11",
     "tslib": "^2.3.0"
   },
+  "scripts": {
+    "set-version": "node tools/scripts/version.mjs"
+  },
   "devDependencies": {
     "@nrwl/esbuild": "^15.8.7",
     "@nrwl/eslint-plugin-nx": "15.8.7",

--- a/packages/sample-data/package.json
+++ b/packages/sample-data/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@brimdata/sample-data",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "type": "commonjs"
 }

--- a/packages/zed-js/package.json
+++ b/packages/zed-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brimdata/zed-js",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "type": "commonjs",
   "exports": "./src/index.js",
   "devDependencies": {

--- a/packages/zed-node/package.json
+++ b/packages/zed-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brimdata/zed-node",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "type": "commonjs",
   "devDependencies": {
     "@types/fs-extra": "^11.0.1",
@@ -8,7 +8,7 @@
     "zed": "github:brimdata/zed#main"
   },
   "dependencies": {
-    "@brimdata/zed-js": "0.0.15",
+    "@brimdata/zed-js": "0.0.16",
     "fs-extra": "^11.1.1",
     "node-fetch": "^2.6.2"
   },

--- a/packages/zed-node/src/lake.ts
+++ b/packages/zed-node/src/lake.ts
@@ -4,8 +4,6 @@ import { join } from 'path';
 import fetch from 'node-fetch';
 import { getZedPath } from './binpath';
 
-const zedCommand = getZedPath();
-
 type ConstructorOpts = {
   root: string;
   logs: string;
@@ -25,7 +23,7 @@ export class Lake {
     this.root = opts.root;
     this.logs = opts.logs;
     this.port = opts.port || 9867;
-    this.bin = opts.bin || zedCommand;
+    this.bin = opts.bin || getZedPath();
     this.cors = opts.corsOrigins || [];
   }
 

--- a/packages/zed-wasm/package.json
+++ b/packages/zed-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brimdata/zed-wasm",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "homepage": "https://github.com/brimdata/zed",
   "type": "module",
   "keywords": [
@@ -15,6 +15,6 @@
     "golang-wasm": "github:teamortix/golang-wasm#master"
   },
   "dependencies": {
-    "@brimdata/zed-js": "0.0.15"
+    "@brimdata/zed-js": "0.0.16"
   }
 }

--- a/tools/scripts/version.mjs
+++ b/tools/scripts/version.mjs
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import path from 'path';
 import fs from 'fs';
 import * as url from 'url';
+import { execSync } from 'child_process';
 
 const args = process.argv.slice(2);
 const version = args[0];
@@ -43,3 +44,5 @@ for (const [name, project] of Object.entries(graph.nodes)) {
   }
   fs.writeFileSync(packageJSON, JSON.stringify(pkg, null, 2) + '\n');
 }
+
+execSync('yarn');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1389,7 +1389,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@brimdata/zed-js@0.0.15, @brimdata/zed-js@workspace:packages/zed-js":
+"@brimdata/zed-js@0.0.16, @brimdata/zed-js@workspace:packages/zed-js":
   version: 0.0.0-use.local
   resolution: "@brimdata/zed-js@workspace:packages/zed-js"
   dependencies:
@@ -1403,7 +1403,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@brimdata/zed-node@workspace:packages/zed-node"
   dependencies:
-    "@brimdata/zed-js": 0.0.15
+    "@brimdata/zed-js": 0.0.16
     "@types/fs-extra": ^11.0.1
     "@types/node-fetch": ^2.6.2
     fs-extra: ^11.1.1
@@ -1418,7 +1418,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@brimdata/zed-wasm@workspace:packages/zed-wasm"
   dependencies:
-    "@brimdata/zed-js": 0.0.15
+    "@brimdata/zed-js": 0.0.16
     "@types/golang-wasm": ^1.15.0
     golang-wasm: "github:teamortix/golang-wasm#master"
   languageName: unknown


### PR DESCRIPTION
There was a problem in the way the code worked before. If there was no zed peer dep, it would throw an error. This prevented a consumer from providing a path to their own zed executable.




- Only try the zed path if consumer doesn't provide a bin option.
- Set version to 0.0.16
