### PR TITLE
Pull in changes from last month

### DIFF
--- a/packages/zed-js/src/client/base-client.ts
+++ b/packages/zed-js/src/client/base-client.ts
@@ -3,7 +3,7 @@ import { PoolConfig, PoolStats } from '../types';
 import { ResultStream } from '../query/result-stream';
 import { createError } from '../util/error';
 import * as Types from './types';
-import { accept, defaults, json, parseContent, toJS, wrapAbort } from './utils';
+import { accept, defaults, parseContent, toJS, wrapAbort } from './utils';
 
 export abstract class BaseClient {
   public abstract fetch: Types.IsoFetch;
@@ -41,7 +41,7 @@ export abstract class BaseClient {
     const result = await this.send({
       method: 'POST',
       path: `/query?ctrl=${options.controlMessages}`,
-      body: json({ query }),
+      body: JSON.stringify({ query }),
       contentType: 'application/json',
       format: options.format,
       signal: abortCtl.signal,
@@ -62,7 +62,7 @@ export abstract class BaseClient {
     return this.send({
       method: 'POST',
       path: '/pool',
-      body: json({ name, layout }),
+      body: JSON.stringify({ name, layout }),
       contentType: 'application/json',
     }).then(toJS);
   }
@@ -102,7 +102,7 @@ export abstract class BaseClient {
     await this.send({
       method: 'PUT',
       path: `/pool/${poolId}`,
-      body: json(args),
+      body: JSON.stringify(args),
       contentType: 'application/json',
     });
     return true;
@@ -137,7 +137,6 @@ export abstract class BaseClient {
   }) {
     const abortCtl = wrapAbort(opts.signal);
     const clearTimer = this.setTimeout(() => {
-      console.error('request timed out:', opts);
       abortCtl.abort();
     }, opts.timeout);
     const headers = { ...opts.headers };

--- a/packages/zed-js/src/client/utils.ts
+++ b/packages/zed-js/src/client/utils.ts
@@ -58,9 +58,13 @@ export async function toJS(res: IsoResponse) {
   const j = await res.json();
   return decode(j).toJS();
 }
+const charsToEncode = /[\u007f-\uffff]/g;
 
-export function json(obj: object) {
-  return JSON.stringify(obj);
+export function jsonHeader(obj: object) {
+  // https://stackoverflow.com/a/40347926
+  return JSON.stringify(obj).replace(charsToEncode, function (c) {
+    return '\\u' + ('000' + c.charCodeAt(0).toString(16)).slice(-4);
+  });
 }
 
 export function wrapAbort(signal?: IsoAbortSignal) {

--- a/packages/zed-node/src/client.ts
+++ b/packages/zed-node/src/client.ts
@@ -3,6 +3,7 @@ import {
   BaseClient,
   LoadOpts,
   getLoadContentType,
+  jsonHeader,
 } from '@brimdata/zed-js';
 import nodeFetch from 'node-fetch';
 
@@ -21,7 +22,7 @@ export class Client extends BaseClient {
     const poolId = typeof pool === 'string' ? pool : pool.id;
     const branch = opts.branch || 'main';
     const headers: Record<string, string> = {};
-    if (opts.message) headers['Zed-Commit'] = JSON.stringify(opts.message);
+    if (opts.message) headers['Zed-Commit'] = jsonHeader(opts.message);
     const res = await this.send({
       path: `/pool/${poolId}/branch/${encodeURIComponent(branch)}`,
       method: 'POST',


### PR DESCRIPTION
The code for the zealot client previously lived in the Zui repo. While I was creating this repo, some changes were made to the code in the zui repo under packages/zealot. This PR pulls in those changes.

The changes summarized are...

* Adding vng (was already in this pepo)
* Adding Float16 and Float32 values and types (was already in this repo)
* Encoding unicode chars in the header messages (needed to be added)

I found these by running the following command in zui on the main branch:

```
git diff '@{3 month ago}' head -- packages/zealot
```
```diff
diff --git a/packages/zealot/package.json b/packages/zealot/package.json
index e7b9fc64..0ba76bb7 100644
--- a/packages/zealot/package.json
+++ b/packages/zealot/package.json
@@ -4,7 +4,7 @@
   "description": "The Javascript Client for Zed Lakes",
   "keywords": [
     "zed",
-    "brim",
+    "zui",
     "zjson",
     "zealot",
     "zedjs"
diff --git a/packages/zealot/src/client/client.test.ts b/packages/zealot/src/client/client.test.ts
index 9142751c..902f6d0c 100644
--- a/packages/zealot/src/client/client.test.ts
+++ b/packages/zealot/src/client/client.test.ts
@@ -159,6 +159,7 @@ test("#load a stream", async () => {
 
 test("#timeout test", async () => {
   jest.useFakeTimers()
+  const client = new Client("http://localhost:9000")
   client.fetch = jest.fn((url, opts = {}) => {
     return new Promise((_, reject) => {
       opts.signal?.addEventListener("abort", () =>
@@ -170,3 +171,13 @@ test("#timeout test", async () => {
   jest.advanceTimersByTime(60_000)
   await expect(p).rejects.toEqual("ABORTED IN MOCK TEST")
 })
+
+test("#load with unicode in commit message", async () => {
+  const {
+    pool: {id},
+  } = await client.createPool("unicode")
+  await client.load("1 2 3", {
+    pool: id,
+    message: {author: "🤷‍♂️", body: "中文测试-⛔️"},
+  })
+})
diff --git a/packages/zealot/src/client/client.ts b/packages/zealot/src/client/client.ts
index 81d6fd7a..dde1c80d 100644
--- a/packages/zealot/src/client/client.ts
+++ b/packages/zealot/src/client/client.ts
@@ -10,7 +10,7 @@ import {
   defaults,
   getEnv,
   getLoadContentType,
-  json,
+  jsonHeader,
   parseContent,
   toJS,
   wrapAbort,
@@ -54,7 +54,7 @@ export class Client {
     const poolId = typeof pool === "string" ? pool : pool.id
     const branch = opts.branch || "main"
     let headers = new Headers()
-    if (opts.message) headers.set("Zed-Commit", json(opts.message))
+    if (opts.message) headers.set("Zed-Commit", jsonHeader(opts.message))
     const res = await this.send({
       path: `/pool/${poolId}/branch/${encodeURIComponent(branch)}`,
       method: "POST",
@@ -77,7 +77,7 @@ export class Client {
     const result = await this.send({
       method: "POST",
       path: `/query?ctrl=${options.controlMessages}`,
-      body: json({query}),
+      body: JSON.stringify({query}),
       contentType: "application/json",
       format: options.format,
       signal: abortCtl.signal,
@@ -97,7 +97,7 @@ export class Client {
     return this.send({
       method: "POST",
       path: "/pool",
-      body: json({name, layout}),
+      body: JSON.stringify({name, layout}),
       contentType: "application/json",
     }).then(toJS)
   }
@@ -137,7 +137,7 @@ export class Client {
     await this.send({
       method: "PUT",
       path: `/pool/${poolId}`,
-      body: json(args),
+      body: JSON.stringify(args),
       contentType: "application/json",
     })
     return true
@@ -173,7 +173,6 @@ export class Client {
   }) {
     const abortCtl = wrapAbort(opts.signal)
     const clearTimer = this.setTimeout(() => {
-      console.error("request timed out:", opts)
       abortCtl.abort()
     }, opts.timeout)
     const fetch = (opts.fetch || this.fetch) as Types.NodeFetch // Make typescript happy
diff --git a/packages/zealot/src/client/types.ts b/packages/zealot/src/client/types.ts
index 9594c0bd..38d47ca5 100644
--- a/packages/zealot/src/client/types.ts
+++ b/packages/zealot/src/client/types.ts
@@ -10,6 +10,7 @@ export type ResponseFormat =
   | "csv"
   | "json"
   | "ndjson"
+  | "vng"
   | "zeek"
   | "zjson"
   | "zng"
@@ -70,6 +71,7 @@ export type LoadFormat =
   | "json"
   | "line"
   | "parquet"
+  | "vng"
   | "zeek"
   | "zjson"
   | "zng"
@@ -82,6 +84,7 @@ export type LoadContentType =
   | "application/json"
   | "application/x-line"
   | "application/x-parquet"
+  | "application/x-vng"
   | "application/x-zeek"
   | "application/x-zjson"
   | "application/x-zng"
diff --git a/packages/zealot/src/client/utils.ts b/packages/zealot/src/client/utils.ts
index 64e3bb6c..a00f6f25 100644
--- a/packages/zealot/src/client/utils.ts
+++ b/packages/zealot/src/client/utils.ts
@@ -31,6 +31,7 @@ export function accept(format: ResponseFormat) {
     csv: "text/csv",
     json: "application/json",
     ndjson: "application/x-ndjson",
+    vng: "application/x-vng",
     zeek: "application/x-zeek",
     zjson: "application/x-zjson",
     zng: "application/x-zng",
@@ -58,8 +59,13 @@ export async function toJS(res: Response | NodeResponse) {
   return decode(j).toJS()
 }
 
-export function json(obj: any) {
-  return JSON.stringify(obj)
+const charsToEncode = /[\u007f-\uffff]/g
+
+export function jsonHeader(obj: any) {
+  // https://stackoverflow.com/a/40347926
+  return JSON.stringify(obj).replace(charsToEncode, function (c) {
+    return "\\u" + ("000" + c.charCodeAt(0).toString(16)).slice(-4)
+  })
 }
 
 export function wrapAbort(signal?: AbortSignal) {
@@ -78,6 +84,7 @@ export function getLoadContentType(
   if (format === "json") return "application/json"
   if (format === "line") return "application/x-line"
   if (format === "parquet") return "application/x-parquet"
+  if (format === "vng") return "application/x-vng"
   if (format === "zeek") return "application/x-zeek"
   if (format === "zjson") return "application/x-zjson"
   if (format === "zng") return "application/x-zng"
diff --git a/packages/zealot/src/lake/lake.ts b/packages/zealot/src/lake/lake.ts
index 6b32164a..d48cb0d9 100644
--- a/packages/zealot/src/lake/lake.ts
+++ b/packages/zealot/src/lake/lake.ts
@@ -53,7 +53,7 @@ export class Lake {
       windowsHide: true,
     }
     // For unix systems, pass posix pipe read file descriptor into lake process.
-    // In the event of Brim getting shutdown via `SIGKILL`, this will let lake
+    // In the event of Zui getting shutdown via `SIGKILL`, this will let lake
     // know that it has been orphaned and to shutdown.
     if (process.platform !== "win32") {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
diff --git a/packages/zealot/src/zed/types/type-float16.ts b/packages/zealot/src/zed/types/type-float16.ts
new file mode 100644
index 00000000..33533b75
--- /dev/null
+++ b/packages/zealot/src/zed/types/type-float16.ts
@@ -0,0 +1,12 @@
+import {Float16} from "../values/float16"
+import {BasePrimitive} from "./base-primitive"
+
+export class TypeOfFloat16 extends BasePrimitive<Float16> {
+  name = "float16"
+
+  create(value: string | null) {
+    return new Float16(value)
+  }
+}
+
+export const TypeFloat16 = new TypeOfFloat16()
diff --git a/packages/zealot/src/zed/types/type-float32.ts b/packages/zealot/src/zed/types/type-float32.ts
new file mode 100644
index 00000000..ecbac368
--- /dev/null
+++ b/packages/zealot/src/zed/types/type-float32.ts
@@ -0,0 +1,12 @@
+import {Float32} from "../values/float32"
+import {BasePrimitive} from "./base-primitive"
+
+export class TypeOfFloat32 extends BasePrimitive<Float32> {
+  name = "float32"
+
+  create(value: string | null) {
+    return new Float32(value)
+  }
+}
+
+export const TypeFloat32 = new TypeOfFloat32()
diff --git a/packages/zealot/src/zed/types/type-primitives.ts b/packages/zealot/src/zed/types/type-primitives.ts
index e39a2e16..a84b9034 100644
--- a/packages/zealot/src/zed/types/type-primitives.ts
+++ b/packages/zealot/src/zed/types/type-primitives.ts
@@ -2,6 +2,8 @@ import {TypeBool} from "./type-bool"
 import {TypeBString} from "./type-bstring"
 import {TypeBytes} from "./type-bytes"
 import {TypeDuration} from "./type-duration"
+import {TypeFloat16} from "./type-float16"
+import {TypeFloat32} from "./type-float32"
 import {TypeFloat64} from "./type-float64"
 import {TypeInt16} from "./type-int16"
 import {TypeInt32} from "./type-int32"
@@ -38,6 +40,8 @@ export const getPrimitives = () => {
     typename: TypeTypename as typeof TypeTypename,
     net: TypeNet as typeof TypeNet,
     float64: TypeFloat64 as typeof TypeFloat64,
+    float32: TypeFloat32 as typeof TypeFloat32,
+    float16: TypeFloat16 as typeof TypeFloat16,
     int32: TypeInt32 as typeof TypeInt32,
     bool: TypeBool as typeof TypeBool,
     bytes: TypeBytes as typeof TypeBytes,
@@ -63,6 +67,8 @@ export function isPrimitiveType(value: unknown): value is PrimitiveType {
     value === TypeTypename ||
     value === TypeNet ||
     value === TypeFloat64 ||
+    value === TypeFloat32 ||
+    value === TypeFloat16 ||
     value === TypeInt32 ||
     value === TypeBool ||
     value === TypeBytes ||
diff --git a/packages/zealot/src/zed/utils/is-container.ts b/packages/zealot/src/zed/utils/is-container.ts
index 5605024f..25e9f4db 100644
--- a/packages/zealot/src/zed/utils/is-container.ts
+++ b/packages/zealot/src/zed/utils/is-container.ts
@@ -4,8 +4,9 @@ import {ZedMap} from "../values/map"
 import {Set} from "../values/set"
 import {Union} from "../values/union"
 import {Error} from "../values/error"
+import {TypeValue} from "../values/type-value"
 
-const containers = [Record, Array, Set, Union, ZedMap, Error]
+const containers = [Record, Array, Set, Union, ZedMap, Error, TypeValue]
 
 export function isContainer(value: unknown) {
   for (let name of containers) {
diff --git a/packages/zealot/src/zed/utils/is-float64.ts b/packages/zealot/src/zed/utils/is-float64.ts
index d0266a59..efe43cb2 100644
--- a/packages/zealot/src/zed/utils/is-float64.ts
+++ b/packages/zealot/src/zed/utils/is-float64.ts
@@ -1,5 +1,15 @@
+import {Float16} from "../values/float16"
+import {Float32} from "../values/float32"
 import {Float64} from "../values/float64"
 
 export function isFloat64(value: unknown): value is Float64 {
   return value instanceof Float64
 }
+
+export function isFloat(value: unknown): value is Float64 | Float32 | Float16 {
+  return (
+    value instanceof Float64 ||
+    value instanceof Float32 ||
+    value instanceof Float16
+  )
+}
diff --git a/packages/zealot/src/zed/values/float16.ts b/packages/zealot/src/zed/values/float16.ts
new file mode 100644
index 00000000..a71b677a
--- /dev/null
+++ b/packages/zealot/src/zed/values/float16.ts
@@ -0,0 +1,16 @@
+import {isNull} from "../utils/is-null"
+import {TypeFloat16} from "../types/type-float16"
+import {Primitive} from "./primitive"
+
+export class Float16 extends Primitive {
+  type: typeof TypeFloat16 = TypeFloat16
+
+  toFloat() {
+    if (isNull(this.value)) return null
+    return parseFloat(this.value)
+  }
+
+  toJS() {
+    return this.toFloat()
+  }
+}
diff --git a/packages/zealot/src/zed/values/float32.ts b/packages/zealot/src/zed/values/float32.ts
new file mode 100644
index 00000000..ed6e6c74
--- /dev/null
+++ b/packages/zealot/src/zed/values/float32.ts
@@ -0,0 +1,16 @@
+import {isNull} from "../utils/is-null"
+import {TypeFloat32} from "../types/type-float32"
+import {Primitive} from "./primitive"
+
+export class Float32 extends Primitive {
+  type: typeof TypeFloat32 = TypeFloat32
+
+  toFloat() {
+    if (isNull(this.value)) return null
+    return parseFloat(this.value)
+  }
+
+  toJS() {
+    return this.toFloat()
+  }
+}
```